### PR TITLE
ERC721 Holder functionality

### DIFF
--- a/contracts/Acct.sol
+++ b/contracts/Acct.sol
@@ -6,6 +6,8 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721Holder.sol";
 import "./interfaces/IAcct.sol";
 import "./interfaces/IOwnerRegistry.sol";
 
@@ -23,7 +25,7 @@ import "./interfaces/IOwnerRegistry.sol";
 
  */
 
-contract Acct is Ownable, IAcct {
+contract Acct is Ownable, IAcct, ERC721Holder {
     using SafeERC20 for ERC20;
 
     uint256 public unlockTime;
@@ -125,5 +127,28 @@ contract Acct is Ownable, IAcct {
 
         // log activity
         emit LogWithdraw(msgSender, _assetAddress, amount);
+    }
+
+    /**
+     * @dev Deposit ERC721 using safeTransferFrom.
+     * @param _tokenAddress NFT Contract to be deposited from.
+     * @param _tokenId the ID of the token to be deposited
+     */
+    function depositERC721(address _tokenAddress, uint256 _tokenId) external override {
+        address self = address(this);
+        address msgSender = _msgSender();
+        IERC721(_tokenAddress).safeTransferFrom(msgSender, self, _tokenId);
+    }
+
+    /**
+     * @dev Withdraw ERC721 using safeTransferFrom.
+     * @param _tokenAddress NFT Contract to be withdrawn from.
+     * @param _tokenId the ID of the token to be withdrawn
+     */
+    function withdrawERC721(address _tokenAddress, uint256 _tokenId) external override onlyOwner isUnlocked {
+        address self = address(this);
+        address msgSender = _msgSender();
+        IERC721(_tokenAddress).safeTransferFrom(self, msgSender, _tokenId);
+        emit LogWithdrawNFT(msgSender, _tokenAddress, _tokenId);
     }
 }

--- a/contracts/OwnerRegistry.sol
+++ b/contracts/OwnerRegistry.sol
@@ -33,8 +33,7 @@ contract OwnerRegistry is ERC721("OwnerRegistry", "OWNER"), IOwnerRegistry {
 
     function burnTo(uint256 tokenId, address newOwner) external override {
         require(_isApprovedOrOwner(_msgSender(), tokenId), "Caller is not owner nor approved");
-        _burn(tokenId);
-
         IOwnable(address(tokenId)).transferOwnership(newOwner);
+        _burn(tokenId);
     }
 }

--- a/contracts/interfaces/IAcct.sol
+++ b/contracts/interfaces/IAcct.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.6.12;
 
 interface IAcct {
     event LogWithdraw(address indexed _from, address indexed _assetAddress, uint256 amount);
+    event LogWithdrawNFT(address indexed _from, address indexed _assetAddress, uint256 tokenId);
     event LogTimeLock(address indexed _from, uint256 oldTime, uint256 newTime);
 
     function setUnlockTime(uint256 newUnlockTime) external;
@@ -17,4 +18,8 @@ interface IAcct {
     function withdrawAllERC20(address _assetAddress) external;
 
     function withdrawERC20(address _assetAddress, uint256 amount) external;
+
+    function depositERC721(address _tokenAddress, uint256 _tokenId) external;
+
+    function withdrawERC721(address _tokenAddress, uint256 _tokenId) external;
 }

--- a/contracts/mocks/ERC721Mock.sol
+++ b/contracts/mocks/ERC721Mock.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+// mock class using ERC20
+contract ERC721Mock is ERC721 {
+    uint256 private counter = 1;
+
+    constructor(
+        string memory name,
+        string memory symbol,
+        address initialAccount
+    ) public ERC721(name, symbol) {
+        mint(initialAccount);
+    }
+
+    function mint(address account) public {
+        _mint(account, counter);
+        counter = counter + 1;
+    }
+}

--- a/test/Acct.js
+++ b/test/Acct.js
@@ -2,6 +2,7 @@ const { expect } = require('chai')
 const Acct = artifacts.require('Acct')
 const OwnerRegistry = artifacts.require('OwnerRegistry')
 const ERC20Mock = artifacts.require('mocks/ERC20Mock')
+const ERC721Mock = artifacts.require('mocks/ERC721Mock')
 
 const { expectRevert, expectEvent, BN, time, balance } = require('@openzeppelin/test-helpers')
 
@@ -12,6 +13,7 @@ contract('Acct', async accounts => {
   let acct
   let registry
   let token
+  let nft
 
   beforeEach(async () => {
     acct = await Acct.new(owner)
@@ -175,6 +177,48 @@ contract('Acct', async accounts => {
         const tx = await acct.setUnlockTime(newUnlockTime)
         await expectEvent(tx, 'LogTimeLock', { _from: owner, oldTime: new BN(unlockTime), newTime: new BN(newUnlockTime) })
       })
+    })
+  })
+  describe('ERC721 functionality', async () => {
+    let unlockTime
+    beforeEach(async () => {
+      // create an NFT
+      nft = await ERC721Mock.new('TestNifty', 'NFT', owner)
+      expect(await nft.balanceOf(owner)).to.be.bignumber.equal('1')
+      unlockTime = (await time.latest()).add(time.duration.weeks(2))
+    })
+
+    it('fails to deposit an NFT from an unapproved contract', async () => {
+      expectRevert.unspecified(acct.depositERC721(nft.address, 1))
+    })
+
+    it('can deposit an NFT from an approved contract', async () => {
+      nft.approve(acct.address, 1)
+      acct.depositERC721(nft.address, 1)
+      expect(await nft.balanceOf(owner)).to.be.bignumber.equal('0')
+      expect(await nft.balanceOf(acct.address)).to.be.bignumber.equal('1')
+    })
+
+    it('can withdraw an NFT', async () => {
+      nft.approve(acct.address, 1)
+      acct.depositERC721(nft.address, 1)
+      expect(await nft.balanceOf(acct.address)).to.be.bignumber.equal('1')
+      expect(await nft.balanceOf(owner)).to.be.bignumber.equal('0')
+      acct.withdrawERC721(nft.address, 1)
+      expect(await nft.balanceOf(owner)).to.be.bignumber.equal('1')
+      expect(await nft.balanceOf(acct.address)).to.be.bignumber.equal('0')
+    })
+
+    it('withdrawNFT emits LogWithdrawNFT', async () => {
+      nft.approve(acct.address, 1)
+      acct.depositERC721(nft.address, 1)
+      const tx = await acct.withdrawERC721(nft.address, 1)
+      expectEvent(tx, 'LogWithdrawNFT', { _from: owner, _assetAddress: nft.address, tokenId: new BN(1) })
+    })
+
+    it('cannot withdraw an NFT when time-locked', async () => {
+      await acct.setUnlockTime(unlockTime)
+      await expectRevert(acct.withdrawERC721(nft.address, 1), 'Acct: time-locked')
     })
   })
 })


### PR DESCRIPTION
This handles basic ERC721 Support, including a deposit method, which is not strictly necessary.

TODO before merge: 
- ~~Confirm that you can deposit an ERC721 using transferFrom directly (write unit test)~~

Future TODO
- Handle circular dependency (Since the Acct can be owned by an ERC721, ensure that we can't deposit the NFT that owns the Acct)

^^ Wrote a unit test (currently failing) which confirms that the issue above is actually an issue. An Account can be permanently locked by:
- Transferring ownership to an NFT
- Transferring the NFT to the Acct Address

This can be addressed in two ways
- Extend the ownable lib to check if the new owner is an ERC721 contract
- Update our depositNFT function to check if the NFT ID matches our self address when cast to a unit256. However, this does not handle an unsafe deposit using 'transferFrom' directly. 

